### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -175,7 +175,7 @@ impl GameUI {
         let score = state.get_score(&question.entry.term).unwrap_or_default();
         if state.mistakes == 0 {
             println!(
-                "{}{}> {} {}(perfect, {} try, {:.}% correct){}",
+                "{}{}> {} {}(perfect, {} try, {}% correct){}",
                 termion::cursor::Up(1),
                 termion::clear::CurrentLine,
                 question.entry.term,
@@ -186,7 +186,7 @@ impl GameUI {
             );
         } else {
             println!(
-                "{}{}> {} {}({} mistakes, {} try, {:.}% correct){}",
+                "{}{}> {} {}({} mistakes, {} try, {}% correct){}",
                 termion::cursor::Up(1),
                 termion::clear::CurrentLine,
                 question.entry.term,


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.